### PR TITLE
UISliders/UITableViewCells aren't usable right now, small fix to make them working.

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1391,6 +1391,10 @@ NSInteger compareViewDepth(id obj1, id obj2, void *context)
                 {
                     return NO;
                 }
+                else if ([touch.view.superview isKindOfClass:[UITableViewCell class]]) 
+                {
+                    return NO;
+                }
             }
         }
     }


### PR DESCRIPTION
First Commit: Cancel the UIPanGestureRecognizer if touchEvent targets a UISlider. (Works for MPVolumeView too.)
Second Commit: Cancel the UITapGestureRecognizer if touchEvent targets a UITableViewCell
