### PR TITLE
.gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+*.DS_Store
+build/
+*.pbxuser
+*.mode1v3
+*.perspectivev3
+.svn/
+*.xcworkspace
+xcuserdata


### PR DESCRIPTION
Please add my little change.

Background: When adding the repository as a readonly submodule the local generated files are recognized as changes by git. This is a little bit annoying. With the .gitignore these files are no longer part of the version control.
After adding it you can cleanup the code from your accidentally added personal files likes .DS_Store, xcuserdata/., ... without loosing functionality.

Thanks in advance.
Karsten
