### PR TITLE
Internal NaN values

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1841,7 +1841,8 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     else if ([gesture isKindOfClass:[UIPanGestureRecognizer class]])
     {
         if ([self viewOrSuperview:touch.view isKindOfClass:[UISlider class]] ||
-            [self viewOrSuperview:touch.view isKindOfClass:[UISwitch class]])
+            [self viewOrSuperview:touch.view isKindOfClass:[UISwitch class]] ||
+			!scrollEnabled)
         {
             return NO;
         }


### PR DESCRIPTION
Hi!

I've noticed some strange behaviors in my implementation of iCarousel. From time to time, my carousel view ends up empty, just eating system resources, even while not visible.

Since I'm fetching the carousel content from a server, it starts off empty. I've also done a smaller wrapper around the carousel (that has it's own delegate). The result of this is that values such as `itemWidth` or `numberOfItems` can initially be `0`. This seems to place the `- (void)step` timer in a constant loop, eating away resources, and also not responding at all to `- (void)reloadData`. I've nailed it down to some of the internal offset values containing `NaN`. This seems to be the result of division by zero on a few places in the code.

I've made a quick fix to make the carousel work for my implementation. Check it out if you like, maybe it's a good way to solve my problem. If not, I'm open to suggestions :)
