### PR TITLE
Fix scrollByNumberOfItems duration 0

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1314,8 +1314,8 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
         decelerating = NO;
         [self disableAnimation];
         scrollOffset = itemWidth * [self clampedIndex:previousItemIndex + itemCount];
-        previousItemIndex = previousItemIndex + itemCount;
         [self didScroll];
+        previousItemIndex = previousItemIndex + itemCount;
         [self depthSortViews];
         [self enableAnimation];
     }


### PR DESCRIPTION
Call to scrollByNumberOfItems it was not working as expected, because it was not calling carouselCurrentItemIndexUpdated, it is happening because the previousItemIndex was already updated, and the iCarousel think that the currentItem was the one already selected.
