### PR TITLE
Compiling without PCH

### DIFF
--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -89,6 +89,8 @@
 //  ARC Helper ends
 
 
+#import <QuartzCore/QuartzCore.h>
+
 #ifdef USING_CHAMELEON
 #define ICAROUSEL_IOS
 #elif defined __IPHONE_OS_VERSION_MAX_ALLOWED
@@ -100,7 +102,6 @@ typedef CGSize NSSize;
 #endif
 
 
-#import <QuartzCore/QuartzCore.h>
 #ifdef ICAROUSEL_IOS
 #import <UIKit/UIKit.h>
 #else


### PR DESCRIPTION
I've been using iCarousel with iOS 5.1 on the latest Xcode without PCH files (to get around Xcode syntax highlighting bugs) and it broke the build: the QuartzCore headers are included after the CGRect typedef is made, resulting in an `unknown type name 'CGRect'` error:

```
In file included from /Users/fred/Code/Teapot/cavemancey-ios/External/iCarousel/iCarousel/iCarousel.m:34:
/Users/fred/Code/Teapot/cavemancey-ios/External/iCarousel/iCarousel/iCarousel.h:96:9: error: unknown type name 'CGRect'
typedef CGRect NSRect;
        ^
/Users/fred/Code/Teapot/cavemancey-ios/External/iCarousel/iCarousel/iCarousel.h:97:9: error: unknown type name 'CGSize'
typedef CGSize NSSize;
        ^
/Users/fred/Code/Teapot/cavemancey-ios/External/iCarousel/iCarousel/iCarousel.m:219:38: error: sending 'NSRect' (aka 'int') to parameter of incompatible type 'CGRect' (aka 'struct CGRect'); 
    if ((self = [super initWithFrame:frame]))
                                     ^~~~~
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIView.h:140:29: note: passing argument to parameter 'frame' here
- (id)initWithFrame:(CGRect)frame;          // default initializer
                            ^
/Users/fred/Code/Teapot/cavemancey-ios/External/iCarousel/iCarousel/iCarousel.m:217:29: warning: conflicting parameter types in implementation of 'initWithFrame:': 'CGRect' (aka 'struct CGRect') vs 'NSRect' (aka 'int')
- (id)initWithFrame:(NSRect)frame
                     ~~~~~~ ^
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS5.1.sdk/System/Library/Frameworks/UIKit.framework/Headers/UIView.h:140:29: note: previous definition is here
- (id)initWithFrame:(CGRect)frame;          // default initializer
                     ~~~~~~ ^
```

My fix just includes the QuartzCore headers a few lines earlier, which should be harmless and fix the bug.

By the way thanks for this great piece of software, saved me a couple days of work!
