### PR TITLE
Removed new LLVM's deprecation warnings

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -33,6 +33,8 @@
 
 #import "iCarousel.h"
 
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 
 #define MIN_TOGGLE_DURATION 0.2f
 #define MAX_TOGGLE_DURATION 0.4f


### PR DESCRIPTION
So that we can keep code backward compatible but remove the new deprecation warnings introduced with Xcode 4.6

See #315
