### PR TITLE
Fixed issue where animation timer could be deallocated but not nilled

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -94,7 +94,7 @@
 @property (nonatomic, assign, getter = isScrolling) BOOL scrolling;
 @property (nonatomic, assign) NSTimeInterval startTime;
 @property (nonatomic, assign) CGFloat startVelocity;
-@property (nonatomic, unsafe_unretained) NSTimer *timer;
+@property (nonatomic, strong) NSTimer *timer;
 @property (nonatomic, assign, getter = isDecelerating) BOOL decelerating;
 @property (nonatomic, assign) CGFloat previousTranslation;
 @property (nonatomic, assign, getter = isWrapEnabled) BOOL wrapEnabled;
@@ -1732,20 +1732,25 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 - (void)startAnimation
 {
-    if (!_timer)
+    if(self.timer) {
+        [self.timer invalidate];
+        self.timer = nil;
+    }
+    
+    if (!self.timer)
     {
-        _timer = [NSTimer scheduledTimerWithTimeInterval:1.0/60.0
-                                                  target:self
-                                                selector:@selector(step)
-                                                userInfo:nil
-                                                 repeats:YES];
+        self.timer = [NSTimer scheduledTimerWithTimeInterval:1.0/60.0
+                                                      target:self
+                                                    selector:@selector(step)
+                                                    userInfo:nil
+                                                     repeats:YES];
     }
 }
 
 - (void)stopAnimation
 {
-    [_timer invalidate];
-    _timer = nil;
+    [self.timer invalidate];
+    self.timer = nil;
 }
 
 - (CGFloat)decelerationDistance


### PR DESCRIPTION
Using iCarousel in an ARC based project (carousel.type =
iCarouselTypeCoverFlow2), I was encountering a situation where the
animation would stop after my app loaded some data and did some
processing. After looking at the issue, I found the animation timer was
being deallocated but not nilled, breaking the logic in startAnimation.

Fix should work for ARC and non-ARC projects.
