### PR TITLE
Allow to disable views reordering if required.

### DIFF
--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -189,6 +189,7 @@ iCarouselOption;
 @property (nonatomic, readonly, getter = isDragging) BOOL dragging;
 @property (nonatomic, readonly, getter = isDecelerating) BOOL decelerating;
 @property (nonatomic, readonly, getter = isScrolling) BOOL scrolling;
+@property (nonatomic, assign) BOOL allowViewDepthReordering;
 
 - (void)scrollByOffset:(CGFloat)offset duration:(NSTimeInterval)duration;
 - (void)scrollToOffset:(CGFloat)offset duration:(NSTimeInterval)duration;

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -176,6 +176,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     _scrollToItemBoundary = YES;
     _ignorePerpendicularSwipes = YES;
     _centerItemWhenSelected = YES;
+    _allowViewDepthReordering = YES;
     
     _contentView = [[UIView alloc] initWithFrame:self.bounds];
     
@@ -799,9 +800,12 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 - (void)depthSortViews
 {
-    for (UIView *view in [[_itemViews allValues] sortedArrayUsingFunction:(NSInteger (*)(id, id, void *))compareViewDepth context:(__bridge void *)self])
+    if (_allowViewDepthReordering)
     {
-        [_contentView bringSubviewToFront:view.superview];
+        for (UIView *view in [[_itemViews allValues] sortedArrayUsingFunction:(NSInteger (*)(id, id, void *))compareViewDepth context:(__bridge void *)self])
+        {
+            [_contentView bringSubviewToFront:view.superview];
+        }
     }
 }
 


### PR DESCRIPTION
Currently selected center view will always be reordered to the front. This
commit allows disabling the reordering if necessary.
