### PR TITLE
ellipse trajectory for rotary mode using a new radiusZ property. 

### DIFF
--- a/Examples/Options Demo/en.lproj/iCarouselExampleViewController.xib
+++ b/Examples/Options Demo/en.lproj/iCarouselExampleViewController.xib
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="7.10">
 	<data>
-		<int key="IBDocument.SystemTarget">1536</int>
-		<string key="IBDocument.SystemVersion">12A206j</string>
-		<string key="IBDocument.InterfaceBuilderVersion">2541</string>
-		<string key="IBDocument.AppKitVersion">1172.1</string>
-		<string key="IBDocument.HIToolboxVersion">613.00</string>
+		<int key="IBDocument.SystemTarget">1552</int>
+		<string key="IBDocument.SystemVersion">11G63b</string>
+		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
+		<string key="IBDocument.AppKitVersion">1138.51</string>
+		<string key="IBDocument.HIToolboxVersion">569.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-			<string key="NS.object.0">1875</string>
+			<string key="NS.object.0">2083</string>
 		</object>
 		<object class="NSArray" key="IBDocument.IntegratedClassDependencies">
 			<bool key="EncodedWithXMLCoder">YES</bool>
@@ -67,7 +67,7 @@
 						<string key="NSFrame">{{0, 186}, {320, 230}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="838375038"/>
+						<reference key="NSNextKeyView" ref="614737016"/>
 						<object class="NSColor" key="IBUIBackgroundColor">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MSAwAA</bytes>
@@ -151,7 +151,7 @@
 						<string key="NSFrame">{{92, 87}, {210, 23}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="614737016"/>
+						<reference key="NSNextKeyView" ref="628207798"/>
 						<string key="NSReuseIdentifierKey">_NS:623</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -174,14 +174,15 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
-						<nil key="IBUIHighlightedColor"/>
-						<int key="IBUIBaselineAdjustment">1</int>
-						<float key="IBUIMinimumFontSize">10</float>
 						<string key="IBUIText">Radius</string>
 						<object class="NSColor" key="IBUITextColor" id="358373105">
 							<int key="NSColorSpace">1</int>
 							<bytes key="NSRGB">MCAwIDAAA</bytes>
+							<string key="IBUIColorCocoaTouchKeyPath">darkTextColor</string>
 						</object>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
 						<object class="IBUIFontDescription" key="IBUIFontDescription" id="841032330">
 							<int key="type">1</int>
 							<double key="pointSize">17</double>
@@ -191,7 +192,43 @@
 							<double key="NSSize">17</double>
 							<int key="NSfFlags">16</int>
 						</object>
-						<int key="IBUIAutoshrinkMode">2</int>
+					</object>
+					<object class="IBUISlider" id="555028122">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{92, 126}, {210, 23}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="474539717"/>
+						<string key="NSReuseIdentifierKey">_NS:623</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<float key="IBUIValue">1</float>
+						<float key="IBUIMinValue">0.0010000000474974513</float>
+						<float key="IBUIMaxValue">2</float>
+					</object>
+					<object class="IBUILabel" id="628207798">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{20, 125}, {66, 21}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="555028122"/>
+						<string key="NSReuseIdentifierKey">_NS:328</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<bool key="IBUIClipsSubviews">YES</bool>
+						<int key="IBUIContentMode">7</int>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Radius Z</string>
+						<reference key="IBUITextColor" ref="358373105"/>
+						<nil key="IBUIHighlightedColor"/>
+						<int key="IBUIBaselineAdjustment">1</int>
+						<float key="IBUIMinimumFontSize">10</float>
+						<reference key="IBUIFontDescription" ref="841032330"/>
+						<reference key="IBUIFont" ref="17989842"/>
 					</object>
 					<object class="IBUISlider" id="936428790">
 						<reference key="NSNextResponder" ref="774585933"/>
@@ -221,19 +258,18 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Arc</string>
+						<reference key="IBUITextColor" ref="358373105"/>
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">1</int>
 						<float key="IBUIMinimumFontSize">10</float>
-						<string key="IBUIText">Arc</string>
-						<reference key="IBUITextColor" ref="358373105"/>
 						<reference key="IBUIFontDescription" ref="841032330"/>
 						<reference key="IBUIFont" ref="17989842"/>
-						<int key="IBUIAutoshrinkMode">2</int>
 					</object>
 					<object class="IBUISlider" id="470023568">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{92, 118}, {210, 23}}</string>
+						<string key="NSFrame">{{92, 168}, {210, 23}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="755523658"/>
@@ -248,7 +284,7 @@
 					<object class="IBUILabel" id="614737016">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 117}, {53, 21}}</string>
+						<string key="NSFrame">{{20, 167}, {53, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="470023568"/>
@@ -258,22 +294,21 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Tilt</string>
+						<reference key="IBUITextColor" ref="358373105"/>
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">1</int>
 						<float key="IBUIMinimumFontSize">10</float>
-						<string key="IBUIText">Tilt</string>
-						<reference key="IBUITextColor" ref="358373105"/>
 						<reference key="IBUIFontDescription" ref="841032330"/>
 						<reference key="IBUIFont" ref="17989842"/>
-						<int key="IBUIAutoshrinkMode">2</int>
 					</object>
 					<object class="IBUISlider" id="800631803">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{92, 149}, {210, 23}}</string>
+						<string key="NSFrame">{{92, 199}, {210, 23}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
-						<reference key="NSNextKeyView" ref="474539717"/>
+						<reference key="NSNextKeyView" ref="838375038"/>
 						<string key="NSReuseIdentifierKey">_NS:623</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
@@ -286,7 +321,7 @@
 					<object class="IBUILabel" id="755523658">
 						<reference key="NSNextResponder" ref="774585933"/>
 						<int key="NSvFlags">292</int>
-						<string key="NSFrame">{{20, 148}, {63, 21}}</string>
+						<string key="NSFrame">{{20, 198}, {63, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
 						<reference key="NSWindow"/>
 						<reference key="NSNextKeyView" ref="800631803"/>
@@ -296,14 +331,13 @@
 						<int key="IBUIContentMode">7</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
 						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<string key="IBUIText">Spacing</string>
+						<reference key="IBUITextColor" ref="358373105"/>
 						<nil key="IBUIHighlightedColor"/>
 						<int key="IBUIBaselineAdjustment">1</int>
 						<float key="IBUIMinimumFontSize">10</float>
-						<string key="IBUIText">Spacing</string>
-						<reference key="IBUITextColor" ref="358373105"/>
 						<reference key="IBUIFontDescription" ref="841032330"/>
 						<reference key="IBUIFont" ref="17989842"/>
-						<int key="IBUIAutoshrinkMode">2</int>
 					</object>
 				</object>
 				<string key="NSFrame">{{0, 20}, {320, 460}}</string>
@@ -397,6 +431,14 @@
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">radiusZSlider</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="555028122"/>
+					</object>
+					<int key="connectionID">58</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
 						<string key="label">dataSource</string>
 						<reference key="source" ref="474539717"/>
 						<reference key="destination" ref="372490531"/>
@@ -487,6 +529,15 @@
 					</object>
 					<int key="connectionID">54</int>
 				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">reloadCarousel</string>
+						<reference key="source" ref="555028122"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">13</int>
+					</object>
+					<int key="connectionID">57</int>
+				</object>
 			</object>
 			<object class="IBMutableOrderedSet" key="objectRecords">
 				<object class="NSArray" key="orderedObjects">
@@ -527,6 +578,8 @@
 							<reference ref="755523658"/>
 							<reference ref="936428790"/>
 							<reference ref="969888200"/>
+							<reference ref="555028122"/>
+							<reference ref="628207798"/>
 						</object>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -645,6 +698,17 @@
 						<reference key="object" ref="969888200"/>
 						<reference key="parent" ref="774585933"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">55</int>
+						<reference key="object" ref="555028122"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">56</int>
+						<reference key="object" ref="628207798"/>
+						<reference key="parent" ref="774585933"/>
+						<string key="objectName">Label - Radius - Z</string>
+					</object>
 				</object>
 			</object>
 			<object class="NSMutableDictionary" key="flattenedProperties">
@@ -673,6 +737,8 @@
 					<string>43.IBPluginDependency</string>
 					<string>50.IBPluginDependency</string>
 					<string>51.IBPluginDependency</string>
+					<string>55.IBPluginDependency</string>
+					<string>56.IBPluginDependency</string>
 					<string>6.IBPluginDependency</string>
 					<string>8.CustomClassName</string>
 					<string>8.IBPluginDependency</string>
@@ -682,6 +748,8 @@
 					<string>iCarouselExampleViewController</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>UIResponder</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 					<string>com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -718,7 +786,7 @@
 				<reference key="dict.values" ref="0"/>
 			</object>
 			<nil key="sourceID"/>
-			<int key="maxID">54</int>
+			<int key="maxID">58</int>
 		</object>
 		<object class="IBClassDescriber" key="IBDocument.Classes">
 			<object class="NSMutableArray" key="referencedPartialClassDescriptions">
@@ -835,6 +903,7 @@
 							<string>navItem</string>
 							<string>orientationBarItem</string>
 							<string>radiusSlider</string>
+							<string>radiusZSlider</string>
 							<string>spacingSlider</string>
 							<string>tiltSlider</string>
 							<string>wrapBarItem</string>
@@ -845,6 +914,7 @@
 							<string>iCarousel</string>
 							<string>UINavigationItem</string>
 							<string>UIBarItem</string>
+							<string>UISlider</string>
 							<string>UISlider</string>
 							<string>UISlider</string>
 							<string>UISlider</string>
@@ -860,6 +930,7 @@
 							<string>navItem</string>
 							<string>orientationBarItem</string>
 							<string>radiusSlider</string>
+							<string>radiusZSlider</string>
 							<string>spacingSlider</string>
 							<string>tiltSlider</string>
 							<string>wrapBarItem</string>
@@ -884,6 +955,10 @@
 							</object>
 							<object class="IBToOneOutletInfo">
 								<string key="name">radiusSlider</string>
+								<string key="candidateClassName">UISlider</string>
+							</object>
+							<object class="IBToOneOutletInfo">
+								<string key="name">radiusZSlider</string>
 								<string key="candidateClassName">UISlider</string>
 							</object>
 							<object class="IBToOneOutletInfo">
@@ -919,6 +994,6 @@
 			<string key="NS.key.0">background.png</string>
 			<string key="NS.object.0">{50, 468}</string>
 		</object>
-		<string key="IBCocoaTouchPluginVersion">1875</string>
+		<string key="IBCocoaTouchPluginVersion">2083</string>
 	</data>
 </archive>

--- a/Examples/Options Demo/iCarouselExampleViewController.h
+++ b/Examples/Options Demo/iCarouselExampleViewController.h
@@ -18,6 +18,7 @@
 @property (nonatomic, retain) IBOutlet UIBarItem *wrapBarItem;
 @property (nonatomic, retain) IBOutlet UISlider *arcSlider;
 @property (nonatomic, retain) IBOutlet UISlider *radiusSlider;
+@property (nonatomic, retain) IBOutlet UISlider *radiusZSlider;
 @property (nonatomic, retain) IBOutlet UISlider *tiltSlider;
 @property (nonatomic, retain) IBOutlet UISlider *spacingSlider;
 

--- a/Examples/Options Demo/iCarouselExampleViewController.m
+++ b/Examples/Options Demo/iCarouselExampleViewController.m
@@ -27,6 +27,7 @@
 @synthesize items;
 @synthesize arcSlider;
 @synthesize radiusSlider;
+@synthesize radiusZSlider;
 @synthesize tiltSlider;
 @synthesize spacingSlider;
 
@@ -73,6 +74,7 @@
     [items release];
     [arcSlider release];
     [radiusSlider release];
+    [radiusZSlider release];
     [tiltSlider release];
     [spacingSlider release];
     [super dealloc];
@@ -89,6 +91,7 @@
         {
             arcSlider.enabled = NO;
         	radiusSlider.enabled = NO;
+        	radiusZSlider.enabled = NO;
             tiltSlider.enabled = NO;
             spacingSlider.enabled = YES;
             break;
@@ -102,6 +105,7 @@
         {
             arcSlider.enabled = YES;
         	radiusSlider.enabled = YES;
+        	radiusZSlider.enabled = YES;
             tiltSlider.enabled = NO;
             spacingSlider.enabled = YES;
             break;
@@ -110,6 +114,7 @@
         {
             arcSlider.enabled = NO;
         	radiusSlider.enabled = NO;
+        	radiusZSlider.enabled = NO;
             tiltSlider.enabled = YES;
             spacingSlider.enabled = YES;
             break;
@@ -136,6 +141,7 @@
     self.wrapBarItem = nil;
     self.arcSlider = nil;
     self.radiusSlider = nil;
+    self.radiusZSlider = nil;
     self.tiltSlider = nil;
     self.spacingSlider = nil;
 }
@@ -281,6 +287,10 @@
         case iCarouselOptionRadius:
         {
             return value * radiusSlider.value;
+        }
+        case iCarouselOptionRadiusZ:
+        {
+            return value * radiusZSlider.value;
         }
         case iCarouselOptionTilt:
         {

--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -93,6 +93,7 @@ typedef enum
     iCarouselOptionArc,
 	iCarouselOptionAngle,
     iCarouselOptionRadius,
+    iCarouselOptionRadiusZ,
     iCarouselOptionTilt,
     iCarouselOptionSpacing,
     iCarouselOptionFadeMin,

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -612,21 +612,23 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             CGFloat spacing = [self valueForOption:iCarouselOptionSpacing withDefault:1.0f];
             CGFloat arc = [self valueForOption:iCarouselOptionArc withDefault:M_PI * 2.0f];
             CGFloat radius = [self valueForOption:iCarouselOptionRadius withDefault:fmaxf(_itemWidth * spacing / 2.0f, _itemWidth * spacing / 2.0f / tanf(arc/2.0f/count))];
+            CGFloat radiusZ = [self valueForOption:iCarouselOptionRadiusZ withDefault:radius];
             CGFloat angle = [self valueForOption:iCarouselOptionAngle withDefault:offset / count * arc];
             
             if (_type == iCarouselTypeInvertedRotary)
             {
                 radius = -radius;
+                radiusZ = -radiusZ;
                 angle = -angle;
             }
             
             if (_vertical)
             {
-                return CATransform3DTranslate(transform, 0.0f, radius * sin(angle), radius * cos(angle) - radius);
+                return CATransform3DTranslate(transform, 0.0f, radius * sin(angle), radiusZ * cos(angle) - radiusZ);
             }
             else
             {
-                return CATransform3DTranslate(transform, radius * sin(angle), 0.0f, radius * cos(angle) - radius);
+                return CATransform3DTranslate(transform, radius * sin(angle), 0.0f, radiusZ * cos(angle) - radiusZ);
             }
         }
         case iCarouselTypeCylinder:


### PR DESCRIPTION
This change is 100% backward compatible. It lets people adjust the shape of the circle for rotary mode into an ellipse. it's useful for when you want to show the items in the back a little closer to the front items without affecting item spacing.
"radiusZ" default is equal to "radius".

The "iCarouselOptionsDemo" example project has been modified to exhibit the feature. 
