### PR TITLE
Add minimum fade alpha option

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,8 +386,9 @@ The spacing between item views. This value is multiplied by the item width (or h
     iCarouselOptionFadeMin
     iCarouselOptionFadeMax
     iCarouselOptionFadeRange
+	iCarouselOptionFadeMinAlpha
 
-These three options control the fading out of carousel item views based on their offset from the currently centered item. FadeMin is the minimum negative offset an item view can reach before it begins to fade. FadeMax is the maximum positive offset a view can reach before if begins to fade. FadeRange is the distance over which the fadeout occurs, measured in multiples of an item width (defaults to 1.0).
+These four options control the fading out of carousel item views based on their offset from the currently centered item. FadeMin is the minimum negative offset an item view can reach before it begins to fade. FadeMax is the maximum positive offset a view can reach before if begins to fade. FadeRange is the distance over which the fadeout occurs, measured in multiples of an item width (defaults to 1.0).  FadeMinAlpha is the minimum alpha value an item view can fade to (defaults to 0.0).
 
 
 Detecting Taps on Item Views

--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -97,7 +97,8 @@ typedef enum
     iCarouselOptionSpacing,
     iCarouselOptionFadeMin,
     iCarouselOptionFadeMax,
-    iCarouselOptionFadeRange
+    iCarouselOptionFadeRange,
+    iCarouselOptionFadeMinAlpha
 }
 iCarouselOption;
 

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -470,6 +470,8 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     CGFloat fadeMin = -INFINITY;
     CGFloat fadeMax = INFINITY;
     CGFloat fadeRange = 1.0f;
+    CGFloat fadeMinAlpha = 0.0f;
+    
     switch (_type)
     {
         case iCarouselTypeTimeMachine:
@@ -487,9 +489,11 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             //do nothing
         }
     }
+    
     fadeMin = [self valueForOption:iCarouselOptionFadeMin withDefault:fadeMin];
     fadeMax = [self valueForOption:iCarouselOptionFadeMax withDefault:fadeMax];
     fadeRange = [self valueForOption:iCarouselOptionFadeRange withDefault:fadeRange];
+    fadeMinAlpha = [self valueForOption:iCarouselOptionFadeMinAlpha withDefault:fadeMinAlpha];
 
 #ifdef ICAROUSEL_MACOS
     
@@ -500,16 +504,19 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     }
     
 #endif
+
+    CGFloat maxAlphaDifference = 1.0 - fadeMinAlpha;
+    CGFloat alphaDifference = 0.0;
     
     if (offset > fadeMax)
     {
-        return 1.0f - fminf(offset - fadeMax, fadeRange) / fadeRange;
+        alphaDifference = (fminf(offset - fadeMax, fadeRange) / fadeRange) * maxAlphaDifference;
     }
     else if (offset < fadeMin)
     {
-        return 1.0f - fminf(fadeMin - offset, fadeRange) / fadeRange;
+        alphaDifference = (fminf(fadeMin - offset, fadeRange) / fadeRange) * maxAlphaDifference;
     }
-    return 1.0f;
+    return 1.0f - alphaDifference;
 }
 
 - (CGFloat)valueForOption:(iCarouselOption)option withDefault:(CGFloat)value


### PR DESCRIPTION
This quickly and cleanly allows a developer to specify a minimum alpha value that items can fade to.  Documentation has been updated to include this option.  The default value of 0.0 makes the carousel work exactly as before.
