### PR TITLE
Issue when item views are the same width as the carousel

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1027,7 +1027,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             //exact number required to fill screen
             CGFloat spacing = [self valueForOption:iCarouselOptionSpacing withDefault:1.0f];
             CGFloat width = _vertical ? self.bounds.size.height: self.bounds.size.width;
-            _numberOfVisibleItems = ceilf((width - _itemWidth) / (spacing * _itemWidth)) + 2;
+            _numberOfVisibleItems = MAX(3, ceilf((width - _itemWidth) / (spacing * _itemWidth)) + 2);
             break;
         }
         case iCarouselTypeCoverFlow:
@@ -1036,7 +1036,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             //exact number required to fill screen
             CGFloat spacing = [self valueForOption:iCarouselOptionSpacing withDefault:0.25f];
             CGFloat width = _vertical ? self.bounds.size.height: self.bounds.size.width;
-            _numberOfVisibleItems = ceilf((width - _itemWidth) / (spacing * _itemWidth)) + 2;
+            _numberOfVisibleItems = MAX(3, ceilf((width - _itemWidth) / (spacing * _itemWidth)) + 2);
             break;
         }
         case iCarouselTypeRotary:


### PR DESCRIPTION
When you have a carousel where the width of the items is the same as the width of the carousel, the next item view doesn't become visible until half of it should be on screen. As far as I can tell, this only happens on the linear and cover flow types.

Heres some screenshots where I modified the example app so the items have the same width as the carousel. The first shows that the next view isn't there and the second shows that once you pass the half way point, it appears.

![img_0195](https://f.cloud.github.com/assets/680442/625996/462acc34-cfb2-11e2-8219-be798b87bbdf.png)_![img_0196](https://f.cloud.github.com/assets/680442/625997/4776e6a4-cfb2-11e2-9390-7edecd2096c2.png)
