### PR TITLE
Implements (BOOL)checksGesturesInSuperview

### DIFF
--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -113,6 +113,7 @@ iCarouselOption;
 @property (nonatomic, assign, getter = isVertical) BOOL vertical;
 @property (nonatomic, readonly, getter = isWrapEnabled) BOOL wrapEnabled;
 @property (nonatomic, assign) BOOL bounces;
+@property (nonatomic, assign) BOOL checksGesturesInSuperview;
 @property (nonatomic, assign) CGFloat scrollOffset;
 @property (nonatomic, readonly) CGFloat offsetMultiplier;
 @property (nonatomic, assign) CGSize contentOffset;

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -134,6 +134,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     _scrollToItemBoundary = YES;
     _ignorePerpendicularSwipes = YES;
     _centerItemWhenSelected = YES;
+    _checksGesturesInSuperview = YES;
     
     _contentView = [[UIView alloc] initWithFrame:self.bounds];
     
@@ -1910,7 +1911,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             {
                 return NO;
             }
-            else if ([self viewOrSuperview:touch.view implementsSelector:@selector(touchesBegan:withEvent:)])
+            else if (_checksGesturesInSuperview && [self viewOrSuperview:touch.view implementsSelector:@selector(touchesBegan:withEvent:)])
             {
                 return NO;
             }
@@ -1918,7 +1919,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     }
     else if ([gesture isKindOfClass:[UIPanGestureRecognizer class]])
     {
-        if (!_scrollEnabled || [self viewOrSuperview:touch.view implementsSelector:@selector(touchesMoved:withEvent:)])
+        if (!_scrollEnabled || (_checksGesturesInSuperview && [self viewOrSuperview:touch.view implementsSelector:@selector(touchesMoved:withEvent:)]))
         {
             return NO;
         }


### PR DESCRIPTION
Set to NO to disable checking if superview handles gestures.

A quick way to disable checking for gesture handlers in superviews. This is needed if iCarousel is embedded in more complex view stack.
