### PR TITLE
Add property to always receive pan touches.

### DIFF
--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -109,6 +109,7 @@ iCarouselOption;
 @property (nonatomic, assign) CGFloat scrollSpeed;
 @property (nonatomic, assign) CGFloat bounceDistance;
 @property (nonatomic, assign, getter = isScrollEnabled) BOOL scrollEnabled;
+@property (nonatomic, assign) BOOL alwaysReceivePanGestureTouches;
 @property (nonatomic, assign, getter = isPagingEnabled) BOOL pagingEnabled;
 @property (nonatomic, assign, getter = isVertical) BOOL vertical;
 @property (nonatomic, readonly, getter = isWrapEnabled) BOOL wrapEnabled;

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1931,7 +1931,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     }
     else if ([gesture isKindOfClass:[UIPanGestureRecognizer class]])
     {
-        if (!_scrollEnabled || [self viewOrSuperview:touch.view implementsSelector:@selector(touchesMoved:withEvent:)])
+        if (!_alwaysReceivePanGestureTouches && (!_scrollEnabled || [self viewOrSuperview:touch.view implementsSelector:@selector(touchesMoved:withEvent:)]))
         {
             return NO;
         }


### PR DESCRIPTION
I'm using iCarousel embedded in a UIScrollView (it is not the only thing in the UIScrollView). The behavior I want is that any touches on the carousel are handled by the carousel, and any touches elsewhere go to the scroll view. The default behavior seemed to be that the carousel would grab any touches on the views, but wouldn't grab touches on the contentview _between_ the views. This patch adds a property that allows configuring the carousel to always grab pan touches.
