### PR TITLE
iCarousel's implementation of -layoutSubviews needs to call super

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -845,6 +845,8 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 - (void)layoutSubviews
 {
+    [super layoutSubviews];
+    
     _contentView.frame = self.bounds;
     [self layOutItemViews];
 }


### PR DESCRIPTION
When adding an iCarousel in interface builder, then adding other views to the view that each of auto layout constraints, I get this error:

```
Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Auto Layout still required after executing -layoutSubviews. iCarousel's implementation of -layoutSubviews needs to call super.'
```

Doing what the exception tells us to do, fixes the problem.

Also, the documentation states that the default implementation is not doing nothing:

```
The default implementation of this method does nothing on iOS 5.1 and earlier.
Otherwise, the default implementation uses any constraints you have set to determine the size and position of any subviews.
```
