### PR TITLE
fix didTap (it was using index function call instead of the index)

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1990,9 +1990,9 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 - (void)didTap:(UITapGestureRecognizer *)tapGesture
 {
+    NSInteger index = [self indexOfItemView:[tapGesture.view.subviews lastObject]];
     if (!_delegate || [_delegate carousel:self shouldSelectItemAtIndex:index])
     {
-        NSInteger index = [self indexOfItemView:[tapGesture.view.subviews lastObject]];
         if (_centerItemWhenSelected && index != self.currentItemIndex)
         {
             [self scrollToItemAtIndex:index animated:YES];


### PR DESCRIPTION
It looks like didTap was not not using the correct index here:
- (void)didTap:(UITapGestureRecognizer *)tapGesture
  {
  if (!_delegate || [_delegate carousel:self shouldSelectItemAtIndex:index])

index here is actually a function: char *index(const char *, int) __POSIX_C_DEPRECATED(200112L);
