### PR TITLE
podspec fix

### DIFF
--- a/iCarousel.podspec
+++ b/iCarousel.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.homepage     = "https://github.com/nicklockwood/iCarousel"
   s.authors      = { "Nick Lockwood" => "support@charcoaldesign.co.uk" }  
   s.source       = { :git => "https://github.com/nicklockwood/iCarousel.git", :tag => "1.7.6" }
-  s.source_files = 'iCarousel'
+  s.source_files = 'iCarousel/*.{h,m}'
   s.requires_arc = true
   s.frameworks = 'QuartzCore'
   s.ios.deployment_target = '4.3'


### PR DESCRIPTION
When using iCarousel as a cocoapod, the error "This class requires automatic reference counting" is triggered.

The solution is to add explicit inclusion for .m (and .h) files from the iCarousel folder...

without it, the default behavior for cocoapods is to _not_ add the ARC compiler flag -fobjc-arc to iCarousel.m, even through requires_arc is set elsewhere in the podspec.
