### PR TITLE
Add autoresizingMask for containerView inside _contentView

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -786,6 +786,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     frame.size.width = _vertical? frame.size.width: _itemWidth;
     frame.size.height = _vertical? _itemWidth: frame.size.height;
     UIView *containerView = [[UIView alloc] initWithFrame:frame];
+    containerView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
     
 #ifdef ICAROUSEL_MACOS
 


### PR DESCRIPTION
Fix bug: Item views not auto resize with iCarousel frame because of missing autoresizingMask on containerView.