### PR TITLE
-[iCarousel reloadData]: layoutIfNeeded call added

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1353,6 +1353,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     
     //layout views
     [self setNeedsLayout];
+    [self layoutIfNeeded];
     
     //fix scroll offset
     if (_numberOfItems > 0 && _scrollOffset < 0.0)


### PR DESCRIPTION
-layoutIfNeeded call added to invoke -layoutSubviews explicitly from -reloadData.
See https://github.com/nicklockwood/iCarousel/issues/586