### PR TITLE
Issue with snapping to View Item if a tap was detected in the iCarousel but not on a iCarousel View Item

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -2078,7 +2078,8 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             [self scrollToItemAtIndex:self.currentItemIndex animated:YES];
         }
     }
-    else {
+    else 
+    {
     	[self scrollToItemAtIndex:self.currentItemIndex animated:YES];
     }
 }

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -2078,6 +2078,9 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
             [self scrollToItemAtIndex:self.currentItemIndex animated:YES];
         }
     }
+    else {
+    	[self scrollToItemAtIndex:self.currentItemIndex animated:YES];
+    }
 }
 
 - (void)didPan:(UIPanGestureRecognizer *)panGesture


### PR DESCRIPTION
**Re-opened from https://github.com/nicklockwood/iCarousel/pull/633 moving the commit to it's own branch to hopefully get this accepted.**


Fixes an issue where if you tap outside of a carousel view item, but within the carousel (like at the end of the carousel) the scrolling will freeze in place and not snap to either the previous selected item or the one that was being scrolled to.

A little hard to explain, let me know if more information is needed here