### PR TITLE
Fix Tap Bug

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -2066,8 +2066,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     {
         if (!_delegate || [_delegate carousel:self shouldSelectItemAtIndex:index])
         {
-            if ((index != self.currentItemIndex && _centerItemWhenSelected) ||
-                (index == self.currentItemIndex && _scrollToItemBoundary))
+            if ((index != self.currentItemIndex && _centerItemWhenSelected))
             {
                 [self scrollToItemAtIndex:index animated:YES];
             }


### PR DESCRIPTION
When I tap card, iCarousel will execute `scrollToItemAtIndex` method, and then will execute `[_delegate carouselDidEndScrollingAnimation:self];`