### PR TITLE
Default scroll animation duration available as a parameter on iCarousel.

### DIFF
--- a/iCarousel/iCarousel.h
+++ b/iCarousel/iCarousel.h
@@ -113,6 +113,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGFloat perspective;
 @property (nonatomic, assign) CGFloat decelerationRate;
 @property (nonatomic, assign) CGFloat scrollSpeed;
+@property (nonatomic, assign) NSTimeInterval defaultScrollDuration;
 @property (nonatomic, assign) CGFloat bounceDistance;
 @property (nonatomic, assign, getter = isScrollEnabled) BOOL scrollEnabled;
 @property (nonatomic, assign, getter = isPagingEnabled) BOOL pagingEnabled;

--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -142,6 +142,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     _contentOffset = CGSizeZero;
     _viewpointOffset = CGSizeZero;
     _scrollSpeed = 1.0;
+    _defaultScrollDuration = SCROLL_DURATION;
     _bounceDistance = 1.0;
     _stopAtItemBoundary = YES;
     _scrollToItemBoundary = YES;
@@ -1492,7 +1493,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
 
 - (void)scrollToItemAtIndex:(NSInteger)index animated:(BOOL)animated
 {   
-    [self scrollToItemAtIndex:index duration:animated? SCROLL_DURATION: 0];
+    [self scrollToItemAtIndex:index duration:animated? self.defaultScrollDuration: 0];
 }
 
 - (void)removeItemAtIndex:(NSInteger)index animated:(BOOL)animated


### PR DESCRIPTION
A simple way to change the default scrolling animation duration on the iCarousel. The start value stays the same, but property would allow to change it for the component user.