### PR TITLE
Fixes issue with autoscroll to empty view

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -1122,7 +1122,7 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     //align
     if (!_scrolling && !_decelerating && !_autoscroll)
     {
-        if (_scrollToItemBoundary)
+        if (_scrollToItemBoundary && self.currentItemIndex != -1)
         {
             [self scrollToItemAtIndex:self.currentItemIndex animated:YES];
         }


### PR DESCRIPTION
Sometimes it happens that iCarousel auto scrolls to item with index -1 which is empty view. This fix solves this problem