### PR TITLE
Conditionally ignore -Wreceiver-is-weak

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -40,7 +40,9 @@
 #endif
 
 
-#pragma GCC diagnostic ignored "-Wreceiver-is-weak"
+#if !defined(__has_warning) || __has_warning("-Wreceiver-is-weak")
+# pragma GCC diagnostic ignored "-Wreceiver-is-weak"
+#endif
 #pragma GCC diagnostic ignored "-Warc-repeated-use-of-weak"
 #pragma GCC diagnostic ignored "-Wobjc-missing-property-synthesis"
 #pragma GCC diagnostic ignored "-Wdirect-ivar-access"


### PR DESCRIPTION
… this warning has been removed from current versions of Clang.

http://lists.llvm.org/pipermail/cfe-commits/Week-of-Mon-20150309/125204.html