### PR TITLE
Removed accessibility trait UIAccessibilityTraitAllowsDirectInteraction

### DIFF
--- a/iCarousel/iCarousel.m
+++ b/iCarousel/iCarousel.m
@@ -170,10 +170,6 @@ NSComparisonResult compareViewDepth(UIView *view1, UIView *view2, iCarousel *sel
     tapGesture.delegate = (id <UIGestureRecognizerDelegate>)self;
     [_contentView addGestureRecognizer:tapGesture];
     
-    //set up accessibility
-    self.accessibilityTraits = UIAccessibilityTraitAllowsDirectInteraction;
-    self.isAccessibilityElement = YES;
-    
 #else
     
     [_contentView setWantsLayer:YES];


### PR DESCRIPTION
as it limit accessibility interactions with subviews and would be a blocker for UI automation as app wont be able to identify any subviews.